### PR TITLE
fix a typo. rename VS for Mac case in tutorial

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,12 +9,12 @@ Xamarin add-in to edit `.resx` files
 
 ## Installation
 
-1. Open Xamarin/MonoDevelop `Add-in Manager`
-1. Add Alpha Channel Add-ins
-  1. Switch to `Galary` Tab
-  1. Use dropdown to choose `Manage Repositories`
+1. Open Xamarin/MonoDevelop `Add-in Manager`. For Visual Studio for Mac, Visual Studio -> `Extension...` opens `Extension Managager`
+2. Add Alpha Channel Add-ins
+  1. Switch to `Gallery` Tab
+  1. Use Repository dropdown to choose `Manage Repositories`
   1. Check Alpha channel and refresh
-1. Install Add-in under name `ResxEditor` (should link to this Github repo in
+3. Install Add-in under name `ResxEditor` (should link to this Github repo in
    description)
 
 ## Usage


### PR DESCRIPTION
although step 3 does not work for me (VS Communinity 2019 for Mac, Catalina, .NET 5, but using 2.0SDK in project)